### PR TITLE
Fixes

### DIFF
--- a/ckanext/transmute/logic/action/get.py
+++ b/ckanext/transmute/logic/action/get.py
@@ -13,7 +13,7 @@ from ckanext.transmute.types import TransmuteData, Field, MODE_COMBINE
 from ckanext.transmute.schema import SchemaParser, SchemaField
 from ckanext.transmute.schema import transmute_schema, validate_schema
 from ckanext.transmute.exception import TransmutatorError
-from ckanext.transmute.utils import get_transmutator
+from ckanext.transmute.utils import get_transmutator, SENTINEL
 
 
 log = logging.getLogger(__name__)
@@ -92,7 +92,7 @@ def mutate_old_fields(data, definition, root):
             data.pop(field_name)
             continue
 
-        if field.default and not value:
+        if field.default is not SENTINEL and not value:
             data[field.name] = value = field.default
 
         if field.default_from and not value:
@@ -101,7 +101,7 @@ def mutate_old_fields(data, definition, root):
         if field.replace_from:
             data[field.name] = value = _replace_from(data, field)
 
-        if field.value:
+        if field.value is not SENTINEL:
             if field.update:
                 if not isinstance(data[field.name], type(field.value)):
                     raise ValidationError(
@@ -148,8 +148,10 @@ def create_new_fields(data, definition, root):
         if field_name in data:
             continue
 
-        if field.default or field.value:
-            data[field_name] = field.default or field.value
+        if field.value is not SENTINEL:
+            data[field_name] = field.value
+        elif field.default is not SENTINEL:
+            data[field_name] = field.default
 
         if field.default_from:
             data[field_name] = _default_from(data, field)

--- a/ckanext/transmute/logic/action/get.py
+++ b/ckanext/transmute/logic/action/get.py
@@ -31,6 +31,7 @@ def transmute(ctx: dict[str, Any], data_dict: TransmuteData) -> dict[str, Any]:
         ctx: CKAN context dict
         data: A data dict to transmute
         schema: schema to transmute data
+        root: a root schema type
 
     Returns:
         Transmuted data dict
@@ -40,19 +41,18 @@ def transmute(ctx: dict[str, Any], data_dict: TransmuteData) -> dict[str, Any]:
     data = data_dict["data"]
     data_ctx.set(data)
     schema = SchemaParser(data_dict["schema"])
-    _transmute_data(data, schema)
+    _transmute_data(data, schema, data_dict["root"])
 
     return data
 
 
-def _transmute_data(data, definition, root="Dataset"):
+def _transmute_data(data, definition, root):
     """Mutates an actual data in `data` dict
 
     Args:
         data (dict: [str, Any]): a data to mutate
         definition (SchemaParser): SchemaParser object
         root (str): a root schema type
-                    the default root is Dataset
     """
 
     schema = definition.types[root]

--- a/ckanext/transmute/schema.py
+++ b/ckanext/transmute/schema.py
@@ -7,6 +7,7 @@ import copy
 from ckan.logic.schema import validator_args
 
 from ckanext.transmute.exception import SchemaParsingError, SchemaFieldError
+from ckanext.transmute.utils import SENTINEL
 
 
 class SchemaField:
@@ -20,9 +21,9 @@ class SchemaField:
         validators: Optional[list] = None,
         multiple: bool = False,
         remove: bool = False,
-        default: Optional[Any] = None,
+        default: Any = SENTINEL,
         default_from: Optional[str] = None,
-        value: Optional[Any] = None,
+        value: Any = SENTINEL,
         replace_from: Optional[str] = None,
         inherit_mode: Optional[str] = None,
         update: bool = False,
@@ -138,9 +139,9 @@ class SchemaParser:
             validators=field_meta.get("validators"),
             multiple=field_meta.get("multiple", False),
             remove=field_meta.get("remove", False),
-            default=field_meta.get("default", None),
+            default=field_meta.get("default", SENTINEL),
             default_from=field_meta.get("default_from", None),
-            value=field_meta.get("value", None),
+            value=field_meta.get("value", SENTINEL),
             replace_from=field_meta.get("replace_from", None),
             inherit_mode=field_meta.get("inherit_mode", "combine"),
             update=field_meta.get("update", False),

--- a/ckanext/transmute/schema.py
+++ b/ckanext/transmute/schema.py
@@ -148,10 +148,11 @@ class SchemaParser:
 
 
 @validator_args
-def transmute_schema(not_missing):
+def transmute_schema(not_missing, default):
     return {
         "data": [not_missing],
         "schema": [not_missing],
+        "root": [default("Dataset")],
     }
 
 

--- a/ckanext/transmute/tests/logic/test_action.py
+++ b/ckanext/transmute/tests/logic/test_action.py
@@ -578,7 +578,7 @@ class TestTransmuteAction:
         assert result["metadata_modified"] == result["metadata_created"]
 
     def test_transmute_new_field_from_default_and_value(self):
-        """Default runs before value"""
+        """Default runs after value"""
         data: dict[str, Any] = {}
 
         tsm_schema = build_schema({"field1": {"default": 101, "value": 102}})
@@ -591,7 +591,7 @@ class TestTransmuteAction:
         )
 
         assert "field1" in result
-        assert result["field1"] == 101
+        assert result["field1"] == 102
 
     def test_transmute_new_field_from_value(self):
         """We can define a new field in schema and it will be

--- a/ckanext/transmute/tests/logic/test_action.py
+++ b/ckanext/transmute/tests/logic/test_action.py
@@ -16,6 +16,21 @@ from ckanext.transmute.types import MODE_FIRST_FILLED
 
 @pytest.mark.ckan_config("ckan.plugins", "scheming_datasets")
 class TestTransmuteAction:
+    def test_custom_root(self):
+        """Action allows using a root different from "Dataset"
+        """
+        result = call_action(
+            "tsm_transmute",
+            data={},
+            schema={
+                "root": "custom",
+                "types": {"custom": {"fields": {"def": {"default": "test"}}}}
+            },
+            root="custom",
+        )
+        assert result == {"def": "test"}
+
+
     def test_transmute_default(self):
         """If the origin evaluates to False it must be replaced
         with the default value

--- a/ckanext/transmute/tests/test_transmutators.py
+++ b/ckanext/transmute/tests/test_transmutators.py
@@ -95,15 +95,14 @@ class TestTransmutators:
             {"field_name": {"validators": [["tsm_trim_string", "0"]]}}
         )
 
-        with pytest.raises(ValidationError) as e:
-            result = call_action(
+        with pytest.raises(ValidationError, match="max_length must be integer"):
+            call_action(
                 "tsm_transmute",
                 data=data,
                 schema=tsm_schema,
                 root="Dataset",
             )
 
-        assert "max_length must be integer" in str(e)
 
     def test_concat_transmutator_with_self(self):
         data: dict[str, Any] = {

--- a/ckanext/transmute/tests/test_transmutators.py
+++ b/ckanext/transmute/tests/test_transmutators.py
@@ -351,3 +351,24 @@ class TestTransmutators:
         )
 
         assert result["field_name"] == []
+
+    @pytest.mark.parametrize("default", [False, 0, "", [], {}, None])
+    def test_default_allows_falsy_values(self, default):
+        """False, 0, "", etc. can be used as a default value"""
+
+        tsm_schema = build_schema(
+            {
+                "field_name": {
+                    "default": default
+                },
+            }
+        )
+
+        result = call_action(
+            "tsm_transmute",
+            data={},
+            schema=tsm_schema,
+            root="Dataset",
+        )
+
+        assert result == {"field_name": default}

--- a/ckanext/transmute/types.py
+++ b/ckanext/transmute/types.py
@@ -9,6 +9,7 @@ from recordclass import RecordClass
 class TransmuteData(TypedDict):
     data: dict[str, Any]
     schema: dict[str, Any]
+    root: str
 
 
 class Field(RecordClass):

--- a/ckanext/transmute/utils.py
+++ b/ckanext/transmute/utils.py
@@ -7,6 +7,7 @@ from ckanext.transmute.exception import UnknownTransmutator
 from ckanext.transmute.interfaces import ITransmute
 from ckanext.transmute.types import MODE_COMBINE, MODE_FIRST_FILLED
 
+SENTINEL = {}
 _transmutator_cache = {}
 log = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,94 @@
+[tool.black]
+# line-length = 88
+# preview = true
+
+[tool.ruff]
+target-version = "py38"
+
+[tool.isort]
+known_ckan = "ckan"
+known_ckanext = "ckanext"
+known_self = "ckanext.transmute"
+sections = "FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,CKAN,CKANEXT,SELF,LOCALFOLDER"
+
+[tool.pytest.ini_options]
+addopts = "--ckan-ini test.ini"
+filterwarnings = [
+               "ignore::sqlalchemy.exc.SADeprecationWarning",
+               "ignore::sqlalchemy.exc.SAWarning",
+               "ignore::DeprecationWarning",
+]
+
+[tool.pyright]
+pythonVersion = "3.7"
+include = ["ckanext"]
+exclude = [
+    "**/test*",
+    "**/migration",
+]
+strict = []
+
+strictParameterNoneValue = true
+
+# Check the meaning of rules here
+# https://github.com/microsoft/pyright/blob/main/docs/configuration.md
+reportFunctionMemberAccess = true # non-standard member accesses for functions
+reportMissingImports = true
+reportMissingModuleSource = true
+reportMissingTypeStubs = false
+reportImportCycles = true
+reportUnusedImport = true
+reportUnusedClass = true
+reportUnusedFunction = true
+reportUnusedVariable = true
+reportDuplicateImport = true
+reportOptionalSubscript = true
+reportOptionalMemberAccess = true
+reportOptionalCall = true
+reportOptionalIterable = true
+reportOptionalContextManager = true
+reportOptionalOperand = true
+reportTypedDictNotRequiredAccess = false # Context won't work with this rule
+reportConstantRedefinition = true
+reportIncompatibleMethodOverride = true
+reportIncompatibleVariableOverride = true
+reportOverlappingOverload = true
+reportUntypedFunctionDecorator = false
+reportUnknownParameterType = true
+reportUnknownArgumentType = false
+reportUnknownLambdaType = false
+reportUnknownMemberType = false
+reportMissingTypeArgument = true
+reportInvalidTypeVarUse = true
+reportCallInDefaultInitializer = true
+reportUnknownVariableType = true
+reportUntypedBaseClass = true
+reportUnnecessaryIsInstance = true
+reportUnnecessaryCast = true
+reportUnnecessaryComparison = true
+reportAssertAlwaysTrue = true
+reportSelfClsParameterName = true
+reportUnusedCallResult = false # allow function calls for side-effect only
+useLibraryCodeForTypes = true
+reportGeneralTypeIssues = true
+reportPropertyTypeMismatch = true
+reportWildcardImportFromLibrary = true
+reportUntypedClassDecorator = false
+reportUntypedNamedTuple = true
+reportPrivateUsage = true
+reportPrivateImportUsage = true
+reportInconsistentConstructor = true
+reportMissingSuperCall = false
+reportUninitializedInstanceVariable = true
+reportInvalidStringEscapeSequence = true
+reportMissingParameterType = true
+reportImplicitStringConcatenation = false
+reportUndefinedVariable = true
+reportUnboundVariable = true
+reportInvalidStubStatement = true
+reportIncompleteStub = true
+reportUnsupportedDunderAll = true
+reportUnusedCoroutine = true
+reportUnnecessaryTypeIgnoreComment = true
+reportMatchNotExhaustive = true
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 ckanext-scheming~=2.1.0
-typing-extensions
-recordclass


### PR DESCRIPTION
* tsm_transmute action ignores root other than Dataset
* `None`, `False`, 0 cannot be used as a default 
* `default` has higher priority than `value` for new fields. It's strange, because existing fields do not use `default` but are overridden by `value`(i.e, for existing fields, `value` has higher precedence)